### PR TITLE
Animated marker begins animation from the second point

### DIFF
--- a/src/AnimatedMarker.js
+++ b/src/AnimatedMarker.js
@@ -61,7 +61,7 @@ L.AnimatedMarker = L.Marker.extend({
         speed = this.options.interval;
 
     // Normalize the transition speed from vertex to vertex
-    if (this._i < len) {
+    if (this._i < len && this.i > 0) {
       speed = this._latlngs[this._i-1].distanceTo(this._latlngs[this._i]) / this.options.distance * this.options.interval;
     }
 
@@ -107,7 +107,7 @@ L.AnimatedMarker = L.Marker.extend({
       this.options.distance = 10;
       this.options.interval = 30;
     }
-    this._i = 1;
+    this._i = 0;
   }
 
 });


### PR DESCRIPTION
The animated marker began the animation from the second point on the polyline that was provided. This fixes the issue mainly by changing the value of the index which was set in setLine.