### PR TITLE
Fix "main" property of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leaflet.AnimatedMarker",
   "version": "1.0.0",
   "description": "This is a Leaflet plugin for animating a marker along a polyline.",
-  "main": "AnimatedMarker.js",
+  "main": "src/AnimatedMarker.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/openplans/Leaflet.AnimatedMarker"


### PR DESCRIPTION
Webpack failed to resolve this package because package.json "main" pointed to AnimatedMarker.js instead of correct path src/AnimatedMarker.js.