### PR TITLE
Don't pause before starting animation

### DIFF
--- a/src/AnimatedMarker.js
+++ b/src/AnimatedMarker.js
@@ -55,7 +55,7 @@ L.AnimatedMarker = L.Marker.extend({
     }
   },
 
-  animate: function() {
+  animate: function(start) {
     var self = this,
         len = this._latlngs.length,
         speed = this.options.interval;
@@ -82,12 +82,12 @@ L.AnimatedMarker = L.Marker.extend({
       } else {
         self.animate();
       }
-    }, speed);
+    }, start ? 0 : speed);
   },
 
   // Start the animation
   start: function() {
-    this.animate();
+    this.animate(true);
   },
 
   // Stop the animation in place


### PR DESCRIPTION
Without this, when you start an animation there's always a timeout where nothing is animated. Usually this is not noticeable but if you use bigger values for interval it becomes more noticeable.  